### PR TITLE
Anchors toegevoegd met de in NGR voorkomende OGC

### DIFF
--- a/docs/services.rst
+++ b/docs/services.rst
@@ -20,8 +20,9 @@ Hierin staat in welke coordinatenstelsels de gegevens beschikbaar zijn, welke la
 In de praktijk worden de diensten zelden op deze manier bevraagd. Het is gebruikelijker om ze via OpenLayers, Leaflet, QGIS, ogr2ogr, `Python <https://pypi.python.org/pypi/OWSLib>`_, etc te benaderen.
 
 .. _wfs:
+.. _OGC-WFS:
 
-*************************<a name="OGC:WFS"></a><a name="OGC-WFS"></a>
+*************************
 Web Feature Service (WFS)
 *************************
 
@@ -140,8 +141,10 @@ Met de GetFeature request is het mogelijk om geometrieen en attributen op te hal
     }
 
 .. _wms:
+.. _OGC-WMS:
+.. _OGC_WMS-1.1.1-http-get-map:
 
-*********************<a name="OGC:WMS"></a><a name="OGC-WMS"></a><a name="OGC:WMS-1.1.1-http-get-map"></a>
+*********************
 Web Map Service (WMS)
 *********************
 
@@ -232,8 +235,9 @@ Dit `resulteert <http://geodata.nationaalgeoregister.nl/ahn2/wms?service=wms&req
         "crs": null
     }
 
+.. _OGC-WMTS:
 
-****************************<a name="OGC:WMTS"></a>
+****************************
 Web Map Tile Services (WMTS)
 ****************************
 
@@ -296,8 +300,10 @@ Configuration parameters for the geo content management solution `Flamingo 4 <ht
 
 .. image:: https://f.cloud.github.com/assets/1814164/350385/7707eab6-a01a-11e2-9d07-0c27a27ec11a.png
     :width: 800px
+    
+.. _OGC-CSW:
 
-***********************************<a name="OGC:CSW"></a>
+***********************************
 Catalogue Service for the Web (CSW)
 ***********************************
 

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -21,7 +21,7 @@ In de praktijk worden de diensten zelden op deze manier bevraagd. Het is gebruik
 
 .. _wfs:
 
-*************************
+*************************<a name="OGC:WFS"></a><a name="OGC-WFS"></a>
 Web Feature Service (WFS)
 *************************
 
@@ -141,7 +141,7 @@ Met de GetFeature request is het mogelijk om geometrieen en attributen op te hal
 
 .. _wms:
 
-*********************
+*********************<a name="OGC:WMS"></a><a name="OGC-WMS"></a><a name="OGC:WMS-1.1.1-http-get-map"></a>
 Web Map Service (WMS)
 *********************
 
@@ -233,7 +233,7 @@ Dit `resulteert <http://geodata.nationaalgeoregister.nl/ahn2/wms?service=wms&req
     }
 
 
-****************************
+****************************<a name="OGC:WMTS"></a>
 Web Map Tile Services (WMTS)
 ****************************
 
@@ -297,7 +297,7 @@ Configuration parameters for the geo content management solution `Flamingo 4 <ht
 .. image:: https://f.cloud.github.com/assets/1814164/350385/7707eab6-a01a-11e2-9d07-0c27a27ec11a.png
     :width: 800px
 
-***********************************
+***********************************<a name="OGC:CSW"></a>
 Catalogue Service for the Web (CSW)
 ***********************************
 


### PR DESCRIPTION
/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString/text()
Op dit moment zijn dit:
OGC:WFS 
OGC:WMS 
OGC:WMS-1.1.1-http-get-map 
OGC:WCS 
OGC:WMTS 
OGC:CSW 
OGC-WMS 
OGC:SOS 
OGC:KML
OGC-WFS
Anchors zijn bookmarks welke niet zichtbaar zijn in de tekst maar wel verspringen naar de juiste plek met een #<type>. Door deze op te nemen in de documentatie kunnen huidige en toekomstige service protocols worden toegelicht in NGR.