### PR TITLE
Fix count and startIndex pairing

### DIFF
--- a/docs/handleidingen.rst
+++ b/docs/handleidingen.rst
@@ -113,6 +113,8 @@ De PDOK services kennen alleen een maximum van 15.000 objecten per request. Dat 
 
 Maar niet altijd. En soms wil je juist de WFS bevragen, met een filter erbij bijvoorbeeld. Dus wat doe je dan als je meer dan die 15.000 objecten wil ophalen? Dan komt een van de handige WFS 2.0.0 functies van pas: ResponsePaging.
 
+.. _wfs-response-paging:
+
 WFS 2.0 ResponsePaging
 ======================
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,10 +46,11 @@ Je vindt deze o.a. in het Nationaal GeoRegister door te zoeken naar ``BAG`` en t
     request = GetFeature
     typeName = bag:pand
     count = 100
+    startIndex = 0
     srsName = EPSG:4326
     outputFormat = json
 
-Het `GeoJSON resultaat <http://geodata.nationaalgeoregister.nl/bag/wfs?service=WFS&request=GetFeature&typeName=bag:pand&count=10&outputFormat=json>`_ kun je bijv. in Leaflet `visualiseren <https://cdn.rawgit.com/ndkv/a9f903c1579ff7609638/raw/01e13989c298330715b8b59194bd1f6512ab475b/index.html>`_ m.b.v. van de ``L.geoJson()`` functie.
+Het `GeoJSON resultaat <http://geodata.nationaalgeoregister.nl/bag/wfs?service=WFS&request=GetFeature&typeName=bag:pand&count=100&startIndex=0&outputFormat=json>`_ kun je bijv. in Leaflet `visualiseren <https://cdn.rawgit.com/ndkv/a9f903c1579ff7609638/raw/01e13989c298330715b8b59194bd1f6512ab475b/index.html>`_ m.b.v. van de ``L.geoJson()`` functie.
 
 .. <iframe width="100%" height="250" frameborder="0" marginheight="0" marginwidth="0" src="https://cdn.rawgit.com/ndkv/a9f903c1579ff7609638/raw/01e13989c298330715b8b59194bd1f6512ab475b/index.html"></iframe>
 

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -113,10 +113,11 @@ Met de GetFeature request is het mogelijk om geometrieën en attributen op te ha
     request=GetFeature&
     typeName=bag:pand&
     count=100&
+    startIndex=0&
     outputFormat=json
 
-`Resultaat <http://geodata.nationaalgeoregister.nl/bag/wfs?service=WFS&request=GetFeature&typeName=bag:pand&count=10&outputFormat=json>`_: een GeoJSON document met daarin de polygonen van de voetafdruk en attributen van elk gebouw.
-
+`Resultaat <http://geodata.nationaalgeoregister.nl/bag/wfs?service=WFS&request=GetFeature&typeName=bag:pand&count=10&startIndex=0&outputFormat=json>`_: een GeoJSON document met daarin de polygonen van de voetafdruk en attributen van elk gebouw.
+Voor meer informatie over de `count` en `startIndex` parameters, zie onze `handleiding <wfs-response-paging>`_.
 .. code-block:: javascript
 
     {


### PR DESCRIPTION
- Where ever count is used, add startIndex.
- Reference the excellent guide about response paging that is already
available but easily missed.

While in here:
- Fix a bug where 100 results are advertized but only 10 obtained in the
 result link.