### PR TITLE
Wearing my janitor clothes:

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,11 @@
+from __future__ import unicode_literals
+
+import os
+
 # -*- coding: utf-8 -*-
 #
-# NationaalGeoRegister documentatie documentation build configuration file, created by
-# sphinx-quickstart on Thu May  2 09:35:18 2013.
+# NationaalGeoRegister documentatie documentation build configuration file,
+# created by sphinx-quickstart on Thu May  2 09:35:18 2013.
 #
 # This file is execfile()d with the current directory set to its containing dir.
 #
@@ -10,8 +14,6 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
-import sys, os
 # import cloud_sptheme as csp
 
 # use Read The Docs theme locally
@@ -19,18 +21,19 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
+
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -43,14 +46,14 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
 master_doc = 'index'
 
 # General information about the project.
-project = u'PDOK / NGR documentatie'
-# copyright = u'2013, Simeon Nedkov'
+project = 'PDOK / NGR documentatie'
+# copyright = '2013, Simeon Nedkov'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -67,36 +70,36 @@ language = 'nl'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 
 # -- Options for HTML output ---------------------------------------------------
@@ -115,54 +118,54 @@ pygments_style = 'sphinx'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# Unused: html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = False
@@ -170,54 +173,54 @@ html_show_copyright = False
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'NationaalGeoRegisterdocumentatiedoc'
 
-
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'NationaalGeoRegisterdocumentatie.tex', u'NationaalGeoRegister documentatie Documentation',
-   u'Simeon Nedkov', 'manual'),
+    ('index', 'NationaalGeoRegisterdocumentatie.tex',
+     'NationaalGeoRegister documentatie Documentation',
+     'Simeon Nedkov', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output --------------------------------------------
@@ -225,12 +228,13 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'nationaalgeoregisterdocumentatie', u'NationaalGeoRegister documentatie Documentation',
-     [u'Simeon Nedkov'], 1)
+    ('index', 'nationaalgeoregisterdocumentatie',
+     'NationaalGeoRegister documentatie Documentation',
+     ['Simeon Nedkov'], 1)
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output ------------------------------------------------
@@ -239,19 +243,21 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'NationaalGeoRegisterdocumentatie', u'NationaalGeoRegister documentatie Documentation',
-   u'Simeon Nedkov', 'NationaalGeoRegisterdocumentatie', 'One line description of project.',
-   'Miscellaneous'),
+    ('index', 'NationaalGeoRegisterdocumentatie',
+     'NationaalGeoRegister documentatie Documentation',
+     'Simeon Nedkov', 'NationaalGeoRegisterdocumentatie',
+     'One line description of project.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -16,6 +16,7 @@ Naam                                                               URL
 ================================================================== ========================================================
 
 .. _data-ngr:
+
 *********************
 Nationaal GeoRegister
 *********************
@@ -27,6 +28,7 @@ Nationaal GeoRegister
 **Toegang tot vector data**: filtreer Brontype op: ``dataset`` of ``service``. Filtreer Online Bronnen op: ``OGC:WFS``, ``ATOM``.
 
 .. _data-pdok:
+
 ************************************
 Publieke Dienstverlening op de Kaart
 ************************************

--- a/docs/downloaden.rst
+++ b/docs/downloaden.rst
@@ -27,7 +27,7 @@ Ga als volgt te werk om een deel van de BAG in QGIS te laden en lokaal in een an
 8. Klik met de rechtermuisknop op ``bag:panden`` en selecteer ``Save As..``
 9. Kies ESRI Shapefile, GeoJSON of KML uit het ``Format`` menu
 10. Klik op de ``Browse`` knop en geef aan waar het bestand opgeslagen moet worden
-11. Kies ``EPSG:4326 - WGS84`` uit het ``CRS`` menu om de coördinaten naar ``lat/lng`` te transformeren. Zie :ref:`coord_trans` voor meer informatie.
+11. Kies ``EPSG:4326 - WGS84`` uit het ``CRS`` menu om de coördinaten naar ``lat/lng`` te transformeren. Zie :ref:`coord-trans` voor meer informatie.
 12. Klik op ``OK``
 
 .. image:: images/qgis-vector-save.png
@@ -68,7 +68,7 @@ Getting the footprints of the first 15000 BAG buildings from the WFS endpoint as
     WFS:"http://geodata.nationaalgeoregister.nl/bagviewer/wfs"
     bagviewer:pand
 
-You can use :ref:`ogrinfo <ogrinfo>` to discover which layers are contained in a WFS endpoint, see the :ref:`ogr2ogr tutorial <ogr2ogr tutorial>`_ for more information.
+You can use :ref:`ogrinfo` to discover which layers are contained in a WFS endpoint, see the :ref:`ogr2ogr tutorial` for more information.
 
 .. ****************************
 .. ATOM

--- a/docs/handleidingen.rst
+++ b/docs/handleidingen.rst
@@ -1,3 +1,6 @@
+.. _bag: https://www.kadaster.nl/wat-is-de-bag
+.. _NGR_WFS: http://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/search?facet.q=protocol%2FOGC%253AWFS&isChild=%27false%27&resultType=details&fast=index&_content_type=json&from=1&to=20&sortBy=relevance
+
 .. NOTE:: Staat de handeling die je wilt verrichten er niet bij? Heb je tips, suggesties of heb je een fout ontdekt? :ref:`Laat het ons weten! <doel-feedback>`
 
 #############
@@ -20,7 +23,7 @@ De PDOK BAG Geocoder plugin voor QGIS is zet adressen om naar coördinaten op de
 .. image:: images/qgis-geocoder.png
     :align: center
 
-Klein nadeeltje van de PDOK Geocoder is dat ie coordinaten in het Nederlandse coordinatenstelsel retourneert. CartoDB, Mapbox, Google Maps, etc. verwachten coordinaten in lat/lng. In :ref:`coord-trans` lees je hoe je coördinaten kan transformeren in o.a. QGIS.
+Klein nadeeltje van de PDOK Geocoder is dat ie coördinaten in het Nederlandse coördinatenstelsel retourneert. CartoDB, Mapbox, Google Maps, etc. verwachten coördinaten in lat/lng. In :ref:`coord-trans` lees je hoe je coördinaten kan transformeren in o.a. QGIS.
 
 Via een API
 ===========
@@ -41,7 +44,7 @@ Coördinatentransformaties
 
 Nederlandse geodata gebruiken het `Rijksdriehoekscoördinatenstelsel <https://nl.wikipedia.org/wiki/Rijksdriehoeksco%C3%B6rdinaten>`_, ook wel bekend als ``Amersfoort / RD New``. RD-coördinaten worden niet (out-of-the-box) door Google Maps, Mapbox, CartoDB, e.a. ondersteund. Deze diensten gebruiken de `WGS84 / Pseudo-Mercator <https://en.wikipedia.org/wiki/Web_Mercator>`_ projectie. Hoewel ``Pseudo-Mercator`` meter [m] als eenheid heeft, gebruiken Google Maps, Mapbox, CartoDB, e.a. *lengte- en breedtegraden* als coördinaten voor vector features. Deze lengte- en breedtegraden duiden een plek aan op de aarde zoals benaderd door de WGS84 ellipsoïde. Om Nederlandse vector data in bijv. Mapbox te visualiseren moet je RD-coördinaten daarom naar WGS84 transformeren i.p.v. Pseudo-Mercator. **Let op**: dit geldt niet voor rasters.
 
-Het transformeren van coördinaten kan in de desktop met :ref:`QGIS <coord-trans-qgis>`, in de browser met :ref:`proj4js <coord-trans-proj4js>` en in de *command line* met :ref:`ogr2ogr <coord-trans-ogr2ogr>`. Om deze tools te gebruiken moet je de EPSG (European Petroleum Survey Group) codes van de coordinatenstelsels weten waartussen je wilt transformeren. Deze vindt je op `epsg.io <http://epsg.io/>`_:
+Het transformeren van coördinaten kan in de desktop met :ref:`QGIS <coord-trans-qgis>`, in de browser met :ref:`proj4js <coord-trans-proj4js>` en in de *command line* met :ref:`ogr2ogr <coord-trans-ogr2ogr>`. Om deze tools te gebruiken moet je de EPSG (European Petroleum Survey Group) codes van de coördinatenstelsels weten waartussen je wilt transformeren. Deze vindt je op `epsg.io <http://epsg.io/>`_:
 
 - ``Amersfoort / RD New`` heeft `EPSG code 28992 <http://epsg.io/28992>`_
 - ``Pseudo-Mercator`` heeft `EPSG code 3857 <http://epsg.io/3857>`_
@@ -57,7 +60,7 @@ Op de desktop: QGIS
 1. Klik met de rechtermuisknop op de laag die je wilt transformeren en selecteer ``Save As..``
 2. Kies ESRI Shapefile, GeoJSON of KML uit het ``Format`` menu
 3. Klik op de ``Browse`` knop en geef aan waar het bestand opgeslagen moet worden
-4. Kies ``EPSG:4326 - WGS84`` uit het ``CRS`` menu om de coordinaten naar ``lat/lng`` te transformeren
+4. Kies ``EPSG:4326 - WGS84`` uit het ``CRS`` menu om de coördinaten naar ``lat/lng`` te transformeren
 5. Klik op ``OK``
 
 .. image:: images/qgis-vector-save.png
@@ -68,11 +71,11 @@ Op de desktop: QGIS
 In de browser: proj4js
 ======================
 
-`proj4js <http://proj4js.org/>`_ is een JavaScript bibliotheek voor het transformeren van coördinaten. 
+De JavaScript bibliotheek `proj4js <http://proj4js.org/>`_ is gemaakt voor het transformeren van coördinaten.
 
 .. code-block:: javascript
 
-    // definitie van de Nederlandse coordinatenstelsel
+    // definitie van de Nederlandse coördinatenstelsel
     var RD = "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +towgs84=565.2369,50.0087,465.658,-0.406857330322398,0.350732676542563,-1.8703473836068,4.0812 +no_defs";
 
     // World Geodetic System, in gebruik door Google Maps, Mapbox, CartoDB, e.a.
@@ -86,11 +89,14 @@ In de browser: proj4js
 In de terminal: ogr2ogr
 =======================
 
-ogr2ogr is een command line utility die een groot aantal geodata formats kan lezen en schrijven. Omzetten van coordinaten in het Nederlandse coordinatenstelsel naar WGS84 gaat als volgt 
+Het programma `ogr2ogr` is een command line utility die een groot aantal geodata formats kan lezen en schrijven. Omzetten van coördinaten in het Nederlandse coördinatenstelsel naar WGS84 gaat als volgt
 
 ::
 
     ogr2ogr -f GeoJSON target.geojson source_RD.geojson -s_src EPSG:28992 -t_srs EPSG:4326
+
+
+.. _wfs-pagination:
 
 ******************
 WFS - pagination
@@ -109,7 +115,7 @@ Conform de WFS specificatie gaat het ophalen met GetFeature requests. Bijvoorbee
     request=GetFeature&
     typename=provincies
 
-De PDOK services kennen alleen een maximum van 15.000 objecten per request. Dat mag, bijvoorbeeld om de belasting op de servers te beperken en te voorkomen dat iemand niet (per ongeluk) alle data ophaalt in zijn browser. Voor datasets van enige omvang betekent dit alleen dat je die niet helemaal in één keer via de WFS kan ophalen. In sommige gevallen kan je je wenden tot de data dumps, te downloaden via ATOM feeds. Zie `<http://geodata.nationaalgeoregister.nl/atom/index.xml>`_
+De PDOK services kennen alleen een maximum van 1000 objecten per request. Dat mag, bijvoorbeeld om de belasting op de servers te beperken en te voorkomen dat iemand niet (per ongeluk) alle data ophaalt in zijn browser. Voor datasets van enige omvang betekent dit alleen dat je die niet helemaal in één keer via de WFS kan ophalen. In sommige gevallen kan je je wenden tot de data dumps, te downloaden via ATOM feeds. Zie `<http://geodata.nationaalgeoregister.nl/atom/index.xml>`_
 
 Maar niet altijd. En soms wil je juist de WFS bevragen, met een filter erbij bijvoorbeeld. Dus wat doe je dan als je meer dan die 15.000 objecten wil ophalen? Dan komt een van de handige WFS 2.0.0 functies van pas: ResponsePaging.
 
@@ -168,10 +174,10 @@ Of slimmer nog, vraag voordat je daadwerkelijk data gaat ophalen met *resulttype
 In dit geval is het `antwoord <http://geodata.nationaalgeoregister.nl/bag/wfs?service=WFS&version=2.0.0&request=GetFeature&typename=bag:ligplaats&resulttype=hits>`_ 11757.
 
 ****************************
-WFS - JSON als output format
+WFS - output formaat
 ****************************
 
-GML is voor veel webontwikkelaars niet de eerste keus. JSON en GeoJSON voor geodata lijken de standaard te worden. Maar een WFS geeft standaard (keurig conform de specs) GML terug op een GetFeature reques. Wederom niet getreurd. Ook het GeoJSON formaat is beschikbaar bij de WFSen die PDOK aanbiedt. Gebruik daarvoor de parameter *outputformat=json* bij een GetFeature request en je krijgt GeoJSON terug. Voorbeeld:
+GML is voor veel webontwikkelaars niet de eerste keus. JSON en GeoJSON voor geodata lijken de standaard te worden. Maar een WFS geeft standaard (keurig conform de specs) GML terug op een GetFeature request. Wederom niet getreurd. Ook het GeoJSON formaat is beschikbaar bij de WFSen die PDOK aanbiedt. Gebruik daarvoor de parameter `outputformat=json` bij een GetFeature request en je krijgt GeoJSON terug. Voorbeeld:
 
 ::
 
@@ -183,7 +189,7 @@ GML is voor veel webontwikkelaars niet de eerste keus. JSON en GeoJSON voor geod
     count=100&
     startindex=100&
     outputformat=json 
-    
+
 Tot slot: een PDOK WFS steunt nog meer formaten. Zie daarvoor het stukje XML over het outputFormat van het GetFeature-deel in uit de Capabilities van een WFS. Dit Capabilities document is op te vragen via bijvoorbeeld:
 
 ::
@@ -204,7 +210,7 @@ Tip van Edward MacGillavry (Webmapper): voeg ``srsName=EPSG:4326`` parameter aan
 ogr2ogr en de BAG (EN)
 **********************
 
-This tutorial shows how to get datasets from the Dutch national geoportal through WFS using the GDAL/OGR toolset.  
+This tutorial shows how to get datasets from the Dutch national geoportal through WFS using the GDAL/OGR toolset.
 
 The GDAL/OGR library is the Swiss army knife for handling geospatial data. GDAL provides functions to read, write and transform raster files (e.g. GeoTIFF). OGR provides the same functionality for vector data.
 
@@ -221,30 +227,32 @@ Easiest way to get it on Windows is through the `OSGeo4W <http://trac.osgeo.org/
 
 Basisregistratie Adressen en Gebouwen
 =====================================
+The *Basisregistratie Addressen en Gebouwen* is a Dutch law in which it is declared and regulated that all address and building information needs to be freely available to it's citizens.
+Litterally translated it means "Base registration Addresses and Buildings" and is abbreviated as *BAG*.
 
 .. NOTE::
 
     This tutorial assumes you are familar with the Web Feature Service. Not sure what that is? Review it :ref:`here <wfs>`. 
 
-In this tutorial we will work with the :ref:`Bassisregistratie Adressen en Gebouwen dataset <bag>`. It contains, amongst others, the footrpints of all the Dutch buildings. It's the basis for this `CitySDK <http://citysdk.waag.nl/buildings/>`_ visualisation. The BAG WFS endpoint is located at::
+In this tutorial we will work with the `Basisregistratie Adressen en Gebouwen dataset (in Dutch) <bag>`_. It contains, amongst others, the footprints of all the Dutch buildings. It's the base for the `CitySDK <http://citysdk.waag.nl/buildings/>`_ visualisation. The BAG WFS endpoint is located at::
 
     http://geodata.nationaalgeoregister.nl/bag/wfs
 
 .. WARNING::
 
-    This particular service is limited to serving a maximum of 15000 features per request. If you need more you'll have to obtain the whole dataset from the ATOM feed or through ExtractNL. 
+    This particular service is limited to serving a maximum of 1000 features per request. If you need more you'll have to obtain the whole dataset from the ATOM feed or through ExtractNL.
 
 .. NOTE::
 
-    Although the focus of this tutorial is on the BAG, the demonstrated worklfow and commands can be used to query any WFS endpoint. See ... for more information on how to search specifically for WFS endpoints in the register.  
+    Although the focus of this tutorial is on the BAG, the demonstrated worklfow and commands can be used to query any WFS endpoint. See NGR_WFS_ for all WFS endpoints in the register.
 
-We'll first investigate the endpoint with the *ogrinfo* utility and retrieve the data with the *ogr2ogr* utility.  
+We'll first investigate the endpoint with the *ogrinfo* utility and retrieve the data with the *ogr2ogr* utility.
 
 .. _ogrinfo:
 
 Investigating the data source with ogrinfo 
 ==========================================
-The *ogrinfo* utility retrieves the metadata of a service. It tells us which layers are available in the service, how many features they contin, in which coordinate reference system is the data stored, etc.
+The *ogrinfo* utility retrieves the metadata of a service. It tells us which layers are available in the service, how many features they contin, in which coördinate reference system is the data stored, etc.
 
 ::
 
@@ -277,11 +285,11 @@ where the enumerated items represent the available layers and their type. The bu
 
     $ ogrinfo -so WFS:"http://geodata.nationaalgeoregister.nl/bag/wfs" bag:pand
 
-The result is the number of features contained in the layer, a listing of their attributes, the coordinate reference system of the layer and a bounding box of the features.
+The result is the number of features contained in the layer, a listing of their attributes, the coördinate reference system of the layer and a bounding box of the features.
 
 .. NOTE::
 
-    Observe the afore mentioned limit: the reported number of features is 15000. There are, of course, more than 15000 buildings in the Netherlands.  
+    Observe the afore mentioned limit: the reported number of features is 15000. There are, of course, more than 15000 buildings in the Netherlands.
 
 
 Getting data with ogr2ogr
@@ -298,10 +306,10 @@ Getting the footprints of the first 15000 buildings as GeoJSON is achieved as::
     bag:pand
 
 
-Transforming - coordinates and formats
+Transforming - coördinates and formats
 ======================================
 
-ogr2ogr's primary function is to transform vector data into different formats and coordinate reference systems. We can do the same with the WFS source; transforming the data from the Dutch coordinate system to lat/lng is done as::
+ogr2ogr's primary function is to transform vector data into different formats and coördinate reference systems. We can do the same with the WFS source; transforming the data from the Dutch coördinate system to lat/lng is done as::
 
     $ ogr2ogr -f GeoJSON footprints.geojson WFS:"http://geodata.nationaalgeoregister.nl/bag/wfs" -t_srs EPSG:4326 bag:pand
 

--- a/docs/handleidingen.rst
+++ b/docs/handleidingen.rst
@@ -1,5 +1,3 @@
-.. _bag: https://www.kadaster.nl/wat-is-de-bag
-.. _NGR_WFS: http://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/search?facet.q=protocol%2FOGC%253AWFS&isChild=%27false%27&resultType=details&fast=index&_content_type=json&from=1&to=20&sortBy=relevance
 
 .. NOTE:: Staat de handeling die je wilt verrichten er niet bij? Heb je tips, suggesties of heb je een fout ontdekt? :ref:`Laat het ons weten! <doel-feedback>`
 
@@ -115,9 +113,9 @@ Conform de WFS specificatie gaat het ophalen met GetFeature requests. Bijvoorbee
     request=GetFeature&
     typename=provincies
 
-De PDOK services kennen alleen een maximum van 1000 objecten per request. Dat mag, bijvoorbeeld om de belasting op de servers te beperken en te voorkomen dat iemand niet (per ongeluk) alle data ophaalt in zijn browser. Voor datasets van enige omvang betekent dit alleen dat je die niet helemaal in één keer via de WFS kan ophalen. In sommige gevallen kan je je wenden tot de data dumps, te downloaden via ATOM feeds. Zie `<http://geodata.nationaalgeoregister.nl/atom/index.xml>`_
+De PDOK services kennen alleen een maximum van 1.000 objecten per request. Dat mag, bijvoorbeeld om de belasting op de servers te beperken en te voorkomen dat iemand niet (per ongeluk) alle data ophaalt in zijn browser. Voor datasets van enige omvang betekent dit alleen dat je die niet helemaal in één keer via de WFS kan ophalen. In sommige gevallen kan je je wenden tot de data dumps, te downloaden via ATOM feeds. Zie `<http://geodata.nationaalgeoregister.nl/atom/index.xml>`_
 
-Maar niet altijd. En soms wil je juist de WFS bevragen, met een filter erbij bijvoorbeeld. Dus wat doe je dan als je meer dan die 15.000 objecten wil ophalen? Dan komt een van de handige WFS 2.0.0 functies van pas: ResponsePaging.
+Maar niet altijd. En soms wil je juist de WFS bevragen, met een filter erbij bijvoorbeeld. Dus wat doe je dan als je meer dan die 1.000 objecten wil ophalen? Dan komt een van de handige WFS 2.0.0 functies van pas: ResponsePaging.
 
 .. _wfs-response-paging:
 
@@ -234,17 +232,17 @@ Litterally translated it means "Base registration Addresses and Buildings" and i
 
     This tutorial assumes you are familar with the Web Feature Service. Not sure what that is? Review it :ref:`here <wfs>`. 
 
-In this tutorial we will work with the `Basisregistratie Adressen en Gebouwen dataset (in Dutch) <bag>`_. It contains, amongst others, the footprints of all the Dutch buildings. It's the base for the `CitySDK <http://citysdk.waag.nl/buildings/>`_ visualisation. The BAG WFS endpoint is located at::
+In this tutorial we will work with the `Basisregistratie Adressen en Gebouwen dataset (in Dutch) <https://www.kadaster.nl/wat-is-de-bag>`_. It contains, amongst others, the footprints of all the Dutch buildings. It's the base for the `CitySDK <http://citysdk.waag.nl/buildings/>`_ visualisation. The BAG WFS endpoint is located at::
 
     http://geodata.nationaalgeoregister.nl/bag/wfs
 
 .. WARNING::
 
-    This particular service is limited to serving a maximum of 1000 features per request. If you need more you'll have to obtain the whole dataset from the ATOM feed or through ExtractNL.
+    This particular service is limited to serving a maximum of 1.000 features per request. If you need more you'll have to obtain the whole dataset from the ATOM feed or through ExtractNL.
 
 .. NOTE::
 
-    Although the focus of this tutorial is on the BAG, the demonstrated worklfow and commands can be used to query any WFS endpoint. See NGR_WFS_ for all WFS endpoints in the register.
+    Although the focus of this tutorial is on the BAG, the demonstrated worklfow and commands can be used to query any WFS endpoint. See `NGR WFS <http://www.nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/search?facet.q=protocol%2FOGC%253AWFS&isChild=%27false%27&resultType=details&fast=index&_content_type=json&from=1&to=20&sortBy=relevance>`_ for all WFS endpoints in the register.
 
 We'll first investigate the endpoint with the *ogrinfo* utility and retrieve the data with the *ogr2ogr* utility.
 
@@ -252,7 +250,7 @@ We'll first investigate the endpoint with the *ogrinfo* utility and retrieve the
 
 Investigating the data source with ogrinfo 
 ==========================================
-The *ogrinfo* utility retrieves the metadata of a service. It tells us which layers are available in the service, how many features they contin, in which coördinate reference system is the data stored, etc.
+The *ogrinfo* utility retrieves the metadata of a service. It tells us which layers are available in the service, how many features they contin, in which coordinate reference system is the data stored, etc.
 
 ::
 
@@ -285,11 +283,11 @@ where the enumerated items represent the available layers and their type. The bu
 
     $ ogrinfo -so WFS:"http://geodata.nationaalgeoregister.nl/bag/wfs" bag:pand
 
-The result is the number of features contained in the layer, a listing of their attributes, the coördinate reference system of the layer and a bounding box of the features.
+The result is the number of features contained in the layer, a listing of their attributes, the coordinate reference system of the layer and a bounding box of the features.
 
 .. NOTE::
 
-    Observe the afore mentioned limit: the reported number of features is 15000. There are, of course, more than 15000 buildings in the Netherlands.
+    Observe the afore mentioned limit: the reported number of features is 1.000. There are, of course, more than 1.000 buildings in the Netherlands.
 
 
 Getting data with ogr2ogr
@@ -299,17 +297,17 @@ The* ogr2ogr* utility allows for reading and writing of many different vector fo
 
     ogr2ogr -f output_format destination source layer
 
-Getting the footprints of the first 15000 buildings as GeoJSON is achieved as::
+Getting the footprints of the first 1.000 buildings as GeoJSON is achieved as::
 
     $ ogr2ogr -f GeoJSON footprints.geojson
     WFS:"http://geodata.nationaalgeoregister.nl/bag/wfs"
     bag:pand
 
 
-Transforming - coördinates and formats
+Transforming - coordinates and formats
 ======================================
 
-ogr2ogr's primary function is to transform vector data into different formats and coördinate reference systems. We can do the same with the WFS source; transforming the data from the Dutch coördinate system to lat/lng is done as::
+ogr2ogr's primary function is to transform vector data into different formats and coordinate reference systems. We can do the same with the WFS source; transforming the data from the Dutch coordinate system to lat/lng is done as::
 
     $ ogr2ogr -f GeoJSON footprints.geojson WFS:"http://geodata.nationaalgeoregister.nl/bag/wfs" -t_srs EPSG:4326 bag:pand
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -70,7 +70,7 @@ QGIS
     :align: center
 
 PDOK/INSPIRE plugins - achtergrondkaart
-==============================
+=======================================
 
 De :ref:`PDOK en INSPIRE plugins <qgis-pdok-inspire-plugins>` geven snel en makkelijk toegang tot veel Nederlandse geodata.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 sphinx
-cloud_sptheme
+sphinx-rtd-theme

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -52,7 +52,7 @@ De Web Feature Service is een webservice voor het opvragen van geografische vect
 
 Zie de `specificatie <http://www.opengeospatial.org/standards/wfs>`_ voor een volledige beschrijving van de WFS standaard. In de GeoServer `WFS documentatie <http://docs.geoserver.org/latest/en/user/services/wfs/index.html>`_ lees je in detail hoe je WFS endpoints kan bevragen. 
 
-In :ref:`webapps` lees je hoe je WFS in Leaflet en OpenLayers aanspreekt. In :ref:`Geodata downloaden` lees je hoe je WFS data kan downloaden met QGIS.
+In :ref:`webapps` lees je hoe je WFS in Leaflet en OpenLayers aanspreekt. In :ref:`downloaden-qgis` lees je hoe je WFS data kan downloaden met QGIS.
 
 GetCapabilities
 ===============
@@ -118,6 +118,7 @@ Met de GetFeature request is het mogelijk om geometrieën en attributen op te ha
 
 `Resultaat <http://geodata.nationaalgeoregister.nl/bag/wfs?service=WFS&request=GetFeature&typeName=bag:pand&count=10&startIndex=0&outputFormat=json>`_: een GeoJSON document met daarin de polygonen van de voetafdruk en attributen van elk gebouw.
 Voor meer informatie over de `count` en `startIndex` parameters, zie onze `handleiding <wfs-response-paging>`_.
+
 .. code-block:: javascript
 
     {
@@ -188,9 +189,9 @@ WMS kent minimaal 3 operaties:
 - **GetMap**: retourneert een statisch afbeelding van een kaart
 - **GetFeatureInfo**: geeft attribuutgegevens van een object op een bepaalde plek op de kaart
 
-Zie de `specificatie <http://www.opengeospatial.org/standards/wms>`_ voor een volledige beschrijving van WMS. In de `GeoSever documentatie <http://docs.geoserver.org/latest/en/user/services/wms/index.html>`_ lees je hoe je WMS concreet kan bevragen.
+Zie de `WMS specificatie <http://www.opengeospatial.org/standards/wms>`_ voor een volledige beschrijving. In de `GeoServer documentatie <http://docs.geoserver.org/latest/en/user/services/wms/index.html>`_ lees je hoe je WMS concreet kan bevragen.
 
-In :ref:`webapps` lees je hoe je WMS in Leaflet en OpenLayers aanspreekt.
+In :ref:`webapps` lees je hoe je WMS met behulp van Leaflet en OpenLayers aanspreekt.
 
 .. _wms-getcapabilities:
 
@@ -205,7 +206,7 @@ De functionaliteit van een WMS endpoint wordt beschreven in een *Capabilities* d
     service=WMS&
     request=GetCapabilities
 
-`Resultaat <http://geodata.nationaalgeoregister.nl/ahn2/wms?service=WMS&request=GetCapabilities>`_: een XML document waarin o.a. de opgeslagen data types, lagen beschreven worden, ondersteunde coordinatenstelsels, etc.
+`Resultaat <http://geodata.nationaalgeoregister.nl/ahn2/wms?service=WMS&request=GetCapabilities>`_: een XML document waarin o.a. de opgeslagen data types, lagen beschreven worden, ondersteunde coördinatenstelsels, etc.
 
 .. code-block:: xml
     :linenos:
@@ -437,7 +438,7 @@ De *GetTile* request haalt een kaartbeeld op.
    &TILECOL=0
    &FORMAT=image/png8
 
-De ``TIlEROW`` en ``TILECOL`` parameters specificeren welk tegel opgehaald moet worden. De ``TILEROW`` parameter is equivalent aan het y-coördinaat en neemt in waarde af naarmate ``y`` groter wordt. ``TILECOL`` parameter is equivalent aan het x-coördinaat en neemt in waarde toe als ``x`` groeit. Het laatste getal van de ``TILEMATRIX`` parameter geeft het zoomniveau weer. Bovenstaand request `haalt de bovenste tegel <http://geodata.nationaalgeoregister.nl/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=brtachtergrondkaart&STYLE=default&TILEMATRIXSET=EPSG:28992&TILEMATRIX=EPSG:28992:0&TILEROW=0&TILECOL=0&FORMAT=image/png8>`_ van de tegelpyramide op.
+De ``TILEROW`` en ``TILECOL`` parameters specificeren welk tegel opgehaald moet worden. De ``TILEROW`` parameter is equivalent aan het y-coördinaat en neemt in waarde af naarmate ``y`` groter wordt. ``TILECOL`` parameter is equivalent aan het x-coördinaat en neemt in waarde toe als ``x`` groeit. Het laatste getal van de ``TILEMATRIX`` parameter geeft het zoomniveau weer. Bovenstaand request `haalt de bovenste tegel <http://geodata.nationaalgeoregister.nl/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=brtachtergrondkaart&STYLE=default&TILEMATRIXSET=EPSG:28992&TILEMATRIX=EPSG:28992:0&TILEROW=0&TILECOL=0&FORMAT=image/png8>`_ van de tegelpyramide op.
 
 .. image:: images/wmts0-0-0.png
     :align: center
@@ -477,9 +478,9 @@ De Tiled Web Service geeft toegang tot opgeknipte kaartafbeeldingen (c.q. tegels
 
 ::
 
-    http://geoserver.example.com/tms/<tms_versie_nummer>/<naam_van_kaart>@<coordinatenstelsel>@<bestandsformaat>/<z>/<x>/<y>.<bestandsfromaat>
+    http://geoserver.example.com/tms/<tms_versie_nummer>/<naam_van_kaart>@<coördinatenstelsel>@<bestandsformaat>/<z>/<x>/<y>.<bestandsfromaat>
 
-waarbij ``z``, ``x``, ``y`` de coordinaten van een kaartafbeelding zijn. Zie de `OSGeo TMS specificatie <http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification>`_ voor meer informatie.
+waarbij ``z``, ``x``, ``y`` de coördinaten van een kaartafbeelding zijn. Zie de `OSGeo TMS specificatie <http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification>`_ voor meer informatie.
 
 De TMS *root resource* is de *Capabilities* document die de beschikbare kaartlagen en de bijbehorende URLs beschrijft. De *Capabilities* document van bijv. het Nationaal GeoRegister TMS endpoint bevindt zich op https://geodata.nationaalgeoregister.nl/tms/1.0.0/
 
@@ -528,6 +529,7 @@ Hoewel TMS geen OGC standaard is wordt het out-of-the-box door Leaflet en OpenLa
     
 
 .. _inspire_atom:
+
 **********
 Atom feeds
 **********
@@ -561,6 +563,7 @@ De Atom feeds van PDOK zijn te vinden op https://www.pdok.nl/en/products/pdok-do
 Atom feeds in het NGR zijn te vinden door het Online Bronnen filter ``Atom`` te gebruiken en/of het zoekresultaat te filtreren op ``Downloadbare bestanden``.
 
 .. _OGC-WCS:
+
 ***********************************
 Web Coverage Service (WCS)
 ***********************************
@@ -570,6 +573,7 @@ Het WCS protocol kan gebruikt worden om multi dimensionale raster data over inte
 INSPIRE werkt aan technical guidelines voor het opzetten van een download service op basis van WCS https://ies-svn.jrc.ec.europa.eu/attachments/download/947/Study_WCS_INSPIRE_v0.3.pdf
 
 .. _OGC-CSW:
+
 ***********************************
 Catalogue Service for the Web (CSW)
 ***********************************
@@ -649,7 +653,7 @@ De belangrijkste aanpasbare parameters van dit request zijn:
 * ``elementSetName`` -- Mogelijke waardes: ``full``, ``summary``
 * ``constraint`` -- de toe te passen filter, zie `Zoeken via filters`_.
 * ``resultType`` -- bepaalt wat er teruggestuurd wordt: resultaten of aantal records die voldoen aan de ``constraint`` filter. Mogelijke waardes: ``results``, ``hits``
-* ``startPosition`` -- bepaalt waar de resultatenlijst start. In combinatie met ``maxRecords`` is het mogelijk om resultaten in delen op te vragen, zie het `GetRecord responses in delen opvragen`_ voorbeeld.
+* ``startPosition`` -- bepaalt waar de resultatenlijst start. In combinatie met ``maxRecords`` is het mogelijk om resultaten in delen op te vragen, zie het `GetRecord resultaten in delen opvragen`_ voorbeeld.
 
 .. NOTE:: Het NGR ondersteunt enkel ``application/xml`` als waarde voor ``outputFormat``. Zie de *GetRecords* request specificatie in de *Capabilities* document.
 
@@ -750,7 +754,7 @@ Eerste 10 metadata records ophalen
     constraint=AnyText+LIKE+%27%25water%25%27
 
 GetRecord resultaten in delen opvragen
--------------------------------------
+--------------------------------------
 
 Het NGR bevat veel metadata records. Door de ``maxRecords`` en ``startPosition`` parameters te gebruiken kan je de metadata records in delen opvragen. Na het ophalen van de eerste 10 records (zie vorige voorbeeld) halen we de volgende 10 records binnen door ``startPosition`` de waarde 10 toe te kennen. `Derde blok van tien records <http://nationaalgeoregister.nl/geonetwork/srv/dut/inspire?service=CSW&version=2.0.2&request=GetRecords&namespace=xmlns%28csw=http://www.opengis.net/cat/csw%29&resultType=results&outputSchema=http://www.opengis.net/cat/csw/2.0.2&outputFormat=application/xml&maxRecords=10&startposition=21&typeNames=csw:Record&elementSetName=full&constraintLanguage=CQL_TEXT&constraint_language_version=1.1.0&constraint=AnyText+LIKE+%27%25water%25%27>`_ halen we binnen met ``maxRecords=10`` en ``startposition=21``.
 


### PR DESCRIPTION
- fix everything sphinx-build complains about except:
  - "Duplicate explicit target name": natural language trumps label
  - "WARNING: document isn't included in any toctree": somebody should
    write that bit in "bekijken.rst" but it's not me(tm).
- go with a fine toothed comb through most of the language bits
- pep8-ify conf.py and be forward compatible using future's unicode
  literals. Also remove unused import.
- Update requirements to include the sphinx_rtd_theme which is the one
  used.

@ndkv: This may need some actual review ;)